### PR TITLE
Remove salt

### DIFF
--- a/index.php
+++ b/index.php
@@ -10,8 +10,7 @@ if (isset($_POST['action']) && $_POST['action'] == 'login') {
 	$passwd = $_POST['passwd'];
 
 	// The password in the DB is hashed, so we need to hash this one to compare
-	$options = ['salt' => ';sdlfkj;sdkjasfkjasd;kfaj;fkasj;'];
-	$hash = password_hash($passwd, PASSWORD_DEFAULT, $options);
+	$hash = password_hash($passwd, PASSWORD_DEFAULT);
 
 	// Open the database
 	$url = 'localhost';


### PR DESCRIPTION
I know this is to show sql injection, but using salt is bad practice here as its deprecated in PHP 7.0
See also the [php documentation](http://php.net/manual/en/function.password-hash.php)

The salt is generated which is preferred over defining your own